### PR TITLE
Add ELB Setup

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,3 +26,11 @@ module "vpc" {
 module "ecr" {
   source = "./modules/ecr"
 }
+
+module "elb" {
+  source = "./modules/elb"
+  load_balancer_sg = module.vpc.load_balancer_sg
+  load_balancer_subnet_a = module.vpc.load_balancer_subnet_a
+  load_balancer_subnet_b = module.vpc.load_balancer_subnet_b
+  hello_vpc = module.vpc.hello_vpc
+}

--- a/terraform/modules/elb/main.tf
+++ b/terraform/modules/elb/main.tf
@@ -1,0 +1,39 @@
+resource "aws_lb" "hello_app_elb" {
+  name               = "hello-app-elb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.load_balancer_sg.id]
+  subnets            = [
+    var.load_balancer_subnet_a.id,
+    var.load_balancer_subnet_b.id,
+  ]
+}
+
+resource "aws_lb_target_group" "hello_ecs_target_group" {
+  name     = "ecs"
+  port     = 5001
+  protocol = "HTTP"
+  vpc_id   = var.hello_vpc.id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    interval            = 300
+    path                = "/"
+    timeout             = 5
+    matcher             = "200"
+    healthy_threshold   = 5
+    unhealthy_threshold = 5
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.hello_app_elb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.hello_ecs_target_group.arn
+  }
+}

--- a/terraform/modules/elb/outputs.tf
+++ b/terraform/modules/elb/outputs.tf
@@ -1,0 +1,7 @@
+output "elb" {
+  value = aws_lb.hello_app_elb
+}
+
+output "ecs_target_group" {
+  value = aws_lb_target_group.hello_ecs_target_group
+}

--- a/terraform/modules/elb/variables.tf
+++ b/terraform/modules/elb/variables.tf
@@ -1,0 +1,6 @@
+variable "load_balancer_sg" {}
+
+variable "load_balancer_subnet_a" {}
+variable "load_balancer_subnet_b" {}
+
+variable "hello_vpc" {}


### PR DESCRIPTION
This PR sets up the ELB:
* Adds an AWS LB (ALB)
* Adds a Target Group for our (eventual) ECS Service (at `5001`)
* Adds a Listener at `80`
* Exposes the LB, and Target Group as Outputs