### PR TITLE
Add naive autoscaling setup

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,3 +44,9 @@ module "ecs" {
   ecs_target_group = module.elb.ecs_target_group
   ecr_path = module.ecr.ecr_path
 }
+
+module "auto_scaling" {
+  source = "./modules/autoscaling"
+  ecs_cluster = module.ecs.ecs_cluster
+  ecs_service = module.ecs.ecs_service
+}

--- a/terraform/modules/autoscaling/main.tf
+++ b/terraform/modules/autoscaling/main.tf
@@ -1,0 +1,39 @@
+resource "aws_appautoscaling_target" "asg_target" {
+  max_capacity = 4
+  min_capacity = 1
+  resource_id = "service/${var.ecs_cluster.name}/${var.ecs_service.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "asg_memory" {
+  name               = "asg-memory"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.asg_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.asg_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.asg_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+
+    target_value       = 80
+  }
+}
+
+resource "aws_appautoscaling_policy" "asg_cpu" {
+  name = "asg-cpu"
+  policy_type = "TargetTrackingScaling"
+  resource_id = aws_appautoscaling_target.asg_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.asg_target.scalable_dimension
+  service_namespace = aws_appautoscaling_target.asg_target.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+
+    target_value = 60
+  }
+}

--- a/terraform/modules/autoscaling/variables.tf
+++ b/terraform/modules/autoscaling/variables.tf
@@ -1,0 +1,3 @@
+variable "ecs_cluster" {}
+
+variable "ecs_service" {}


### PR DESCRIPTION
Add a relatively naive (based on standard ECS CPU/Memory metrics) autoscaling setup. 